### PR TITLE
Update node-esp8266-generic.ino

### DIFF
--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -276,7 +276,7 @@ void gsm_poweron();
 void gsm_SleepMode2On();
 void gsm_SleepModeOff();
 bool mqtt_connect();
-void transmit_reaadings();
+void transmit_readings();
 void setup_weight();
 void read_weight();
 void setup_tempsensor();


### PR DESCRIPTION
Tippfehler in Deklaration `transmit_readings()` korrigiert.