### PR TITLE
Modernize "node-esp8266-generic"

### DIFF
--- a/doc/source/firmware/node-esp32-generic
+++ b/doc/source/firmware/node-esp32-generic
@@ -1,0 +1,1 @@
+../../../node-esp32-generic

--- a/doc/source/firmware/node-esp8266-generic
+++ b/doc/source/firmware/node-esp8266-generic
@@ -1,0 +1,1 @@
+../../../node-esp8266-generic

--- a/doc/source/resources.rst
+++ b/doc/source/resources.rst
@@ -66,6 +66,8 @@
 
 .. ulmi
 .. _node-esp8266-generic.ino: https://github.com/hiveeyes/arduino/blob/master/node-esp8266-generic/node-esp8266-generic.ino
+.. _node-esp32-generic.ino: https://github.com/hiveeyes/arduino/blob/master/node-esp32-generic/node-esp32-generic.ino
+
 .. Kotori
 .. _Kotori: https://getkotori.org/docs/
 

--- a/doc/source/resources.rst
+++ b/doc/source/resources.rst
@@ -64,6 +64,8 @@
 .. _node-wifi-mqtt-homie.ino: https://github.com/hiveeyes/arduino/blob/master/node-wifi-mqtt-homie/node-wifi-mqtt-homie.ino
 .. _node-wifi-mqtt-homie-battery.ino: https://github.com/hiveeyes/arduino/blob/master/node-wifi-mqtt-homie-battery/node-wifi-mqtt-homie-battery.ino
 
+.. ulmi
+.. _node-esp8266-generic.ino: https://github.com/hiveeyes/arduino/blob/master/node-esp8266-generic/node-esp8266-generic.ino
 .. Kotori
 .. _Kotori: https://getkotori.org/docs/
 
@@ -166,6 +168,9 @@
 .. _HTTPie: http://httpie.org
 .. _HttpRequester: https://addons.mozilla.org/en-us/firefox/addon/httprequester/
 
+
+.. _PlatformIO: https://platformio.org/
+.. _NodeMCU: https://en.wikipedia.org/wiki/NodeMCU
 
 
 .. Clearfix in reStructuredText

--- a/node-esp8266-generic/Makefile
+++ b/node-esp8266-generic/Makefile
@@ -1,0 +1,15 @@
+$(eval venvpath  := .venv)
+$(eval python    := $(venvpath)/bin/python)
+$(eval pip       := $(venvpath)/bin/pip)
+$(eval pio       := $(venvpath)/bin/pio)
+
+
+build: setup-virtualenv
+	$(pio) run
+
+upload: setup-virtualenv
+	$(pio) run --target upload --upload-port=${MCU_PORT}
+
+setup-virtualenv:
+	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	$(pip) install platformio

--- a/node-esp8266-generic/README.rst
+++ b/node-esp8266-generic/README.rst
@@ -1,0 +1,150 @@
+.. include:: ../../resources.rst
+
+.. _node-esp8266-generic:
+
+#######################
+Bienenwaage 2.0 NodeMCU
+#######################
+
+.. contents::
+   :local:
+   :depth: 1
+
+----
+
+.. tip::
+
+    You might want to `read this document on our documentation space <https://hiveeyes.org/docs/arduino/firmware/node-esp8266-generic/README.html>`_,
+    all inline links will be working there.
+
+
+*****
+About
+*****
+A beehive monitor firmware for ESP8266.
+
+:Author: Stefan Ulmer <ulmi [ät] gmx.de>
+
+Details
+=======
+
+A beehive monitoring sensor node based on the NodeMCU_ hardware, featuring an ESP8266_ MCU.
+Telemetry data is transmitted using MQTT over WiFi or GSM.
+The most recent firmware version is available at `node-esp8266-generic.ino`_.
+
+
+********
+Features
+********
+- Equipped for NodeMCU_, but suitable to run on any ESP8266_ device
+- Sensors: 2x Temperature via DS18B20_, 2x Weight via HX711_, Battery level via ADC
+- GSM/GPRS via SIM800/TinyGSM
+- WiFi via ESP8266
+- Telemetry via MQTT
+
+
+*************
+Documentation
+*************
+- https://community.hiveeyes.org/t/inbetriebnahme-und-weiterentwicklung-der-firmware-fur-arduino-node-esp8266-generic-node-esp32-generic/3189
+
+
+*************
+Configuration
+*************
+
+General
+=======
+In order to toggle different features and modes, please have a look
+at the list of ``#define`` constants at the top of the sketch.
+
+Weight scale
+============
+Adjust ``SCALE_DOUT_PIN_{A,B}``, ``SCALE_SCK_PIN_{A,B}``, ``Taragewicht_{A,B}`` and ``Skalierung_{A,B}``.
+To find out about appropriate values for ``Taragewicht_X`` and ``Skalierung_X``,
+please use a weight scale adjustment sketch like
+https://github.com/hiveeyes/arduino/tree/master/scale-adjust/HX711.
+
+::
+
+    // Scale settings
+    #define WEIGHT                  true
+    float Taragewicht_A = 226743;
+    float Skalierung_A = 41.647;
+    float Taragewicht_B = -238537
+    float Skalierung_B = -42.614;
+
+Temperature sensors
+===================
+Adjust ``SENSOR_DS18B20``, ``DS18B20_PIN`` and the device addresses ``SensorX``.
+
+More sensors
+============
+Adjust ``SENSOR_BATTERY_LEVEL``.
+
+WiFi
+====
+To configure WiFi SSID and credentials, please use the captive portal
+available on X.X.X.X when the device starts in AP mode.
+
+GSM
+===
+To configure GSM/GPRS connectivity, please adjust the ``GSM_ENABLED``,
+``apn[]``, ``user[]``, ``pass[]`` and ``simPIN[]`` variables.
+
+MQTT
+====
+To configure MQTT telemetry, adjust the ``MQTT_BROKER``, ``MQTT_PORT``,
+``MQTT_USERNAME``, ``MQTT_PASSWORD`` and ``MQTT_TOPIC`` variables.
+
+Weather Underground
+===================
+To enable Weather Underground for getting nearby temperature and humidity
+information, adjust ``WUG_API_KEY`` and ``WUG_STATION_ID``.
+
+
+******************
+Build instructions
+******************
+::
+
+    make
+
+After successfully building it, you will find firmware images at
+
+- .pio/build/nodemcu/firmware.bin
+- .pio/build/nodemcu/firmware.elf
+
+
+********
+Firmware
+********
+.. highlight:: bash
+
+
+Clone git repository
+====================
+::
+
+    # Get hold of the source code repository including all dependencies
+    git clone --recursive https://github.com/hiveeyes/arduino
+
+    # Select this firmware
+    cd node-esp8266-generic
+
+
+Build
+=====
+
+The build system is based on PlatformIO_.
+
+Build firmware::
+
+    make
+
+Upload to MCU
+=============
+::
+
+    export MCU_PORT=/dev/ttyUSB0
+    make upload

--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -51,7 +51,7 @@ Shield Lila
 //Version 1.20 public - User / Login Credentials entfernt
 
 
-#define GSM_ENABLED             true    //Bei FALSE wird automatisch WIFI aktiviert
+#define GSM_ENABLED             false  // Bei FALSE wird automatisch WIFI aktiviert
 #define WEIGHT                  true
 #define SENSOR_DS18B20          false  // Aktuell ohne Funktion, da zu wenig PINS zwangsweise false da ich pin D5 für die Waage benötige
 #define SENSOR_BATTERY_LEVEL    false  // falls Spannungsmessung über Spannungsteiler erfolgen soll, wenn kein SIM800 Modul verwendet wird.

--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -196,8 +196,8 @@ Adafruit_MQTT_Publish mqtt_publisher = Adafruit_MQTT_Publish(&mqtt, MQTT_TOPIC);
   #define SCALE_DOUT_PIN_B D2 // DT
   #define SCALE_SCK_PIN_B D1 // SCK
 
-  HX711 scale_A(SCALE_DOUT_PIN_A, SCALE_SCK_PIN_A);
-  HX711 scale_B(SCALE_DOUT_PIN_B, SCALE_SCK_PIN_B);
+  HX711 scale_A;
+  HX711 scale_B;
 
   long AktuellesGewicht_A = 0;
   long AktuellesGewicht_B = 0;
@@ -380,6 +380,10 @@ void loop() {
 void setup_weight() {
 
   #if WEIGHT
+
+    scale_A.begin(SCALE_DOUT_PIN_A, SCALE_SCK_PIN_A);
+    scale_B.begin(SCALE_DOUT_PIN_B, SCALE_SCK_PIN_B);
+
     // Waage A Setup
     scale_A.set_offset(Taragewicht_A);
     scale_A.set_scale(Skalierung_A);

--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -159,7 +159,7 @@ int sleepTimeS = 900;  // 15-Minuten SleepTimer als Startwert
 #define MQTT_PASSWORD       "DeinKennwort"
 
 // The MQTT topic to transmit sensor readings to.
-#define MQTT_TOPIC          "hiveeyes/testdrive/spielwiese/node-1/data.json"
+#define MQTT_TOPIC          "hiveeyes/testdrive/area-42/node-1/data.json"
 
 
 #if GSM_ENABLED

--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -49,15 +49,16 @@ Shield Lila
 //Version 1.19 Echtdaten werden an als node-2 geführt deshabl spielwiese/node-2/data.json, anstatt node-4 an den bisher zu testzwecken übermittelt wurde.
 //Version 1.20 Version um Tippfehler bereinigt und für Upload auf GitHub vorbereitet
 //Version 1.20 public - User / Login Credentials entfernt
+//Version 1.21 Modernisierung und PlatformIO Build-Umgebung
 
 
 #define GSM_ENABLED             false  // Bei FALSE wird automatisch WIFI aktiviert
 #define WEIGHT                  true
 #define SENSOR_DS18B20          false  // Aktuell ohne Funktion, da zu wenig PINS zwangsweise false da ich pin D5 für die Waage benötige
-#define SENSOR_BATTERY_LEVEL    false  // falls Spannungsmessung über Spannungsteiler erfolgen soll, wenn kein SIM800 Modul verwendet wird.
+#define SENSOR_BATTERY_LEVEL    false  // Falls Spannungsmessung über Spannungsteiler erfolgen soll, wenn kein SIM800 Modul verwendet wird.
 #define DEEPSLEEP_ENABLED       true   // Code ist aktuell nur auf TRUE ausgelegt, falls False, muß noch im main() ein Delay eingebaut werden.
-#define SLEEP_TIMER             true   // SleepDauer abhängig vom Ladezustand, Sleep_Timer noch nicht mit Wifi verifziert.
-#define WUNDERGROUND            false  //funktionert aktuell nur mit GSM_ENABLED false
+#define SLEEP_TIMER             true   // Sleep-Dauer abhängig vom Ladezustand, Sleep_Timer noch nicht mit Wifi verifziert.
+#define WUNDERGROUND            false  // Funktionert aktuell nur mit GSM_ENABLED false
 
 
 #if GSM_ENABLED
@@ -639,10 +640,13 @@ void setup_tempsensor() {
 
   Serial.println("Temperaturmessung mit dem DS18B20 ");
 
-  // Start Dallas Tempeartur Library / Instanz
+  // Start Dallas Temperature Library / Instanz
   sensors.begin();  // DS18B20 starten
 
   // Präzision auf 12 Bit
+#ifndef TEMP_12_BIT
+#define TEMP_12_BIT 0x7F // 12 bit
+#endif
   sensors.setResolution(TEMP_12_BIT);
 
   //Anzahl Sensoren ausgeben

--- a/node-esp8266-generic/platformio.ini
+++ b/node-esp8266-generic/platformio.ini
@@ -1,0 +1,30 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:nodemcu]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino
+
+monitor_speed = 115200
+
+lib_deps =
+    OneWire@2.3.5
+    HX711@0.7.4
+    DallasTemperature@3.8.1
+    RunningMedian@0.1.15
+    ArduinoJson@^5
+    https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048
+    tzapu/WiFiManager@^0.16.0
+    vshymanskyy/TinyGSM@^0.10.9
+    tardate/TextFinder

--- a/node-wifi-mqtt/README.rst
+++ b/node-wifi-mqtt/README.rst
@@ -120,6 +120,3 @@ Upload to MCU
 
     export MCU_PORT=/dev/ttyUSB0
     make upload
-
-
-.. _PlatformIO: https://platformio.org/


### PR DESCRIPTION
Hi there,

in order to resolve #31, this patch brings in a build environment based on PlatformIO. In order to make the program compile, some minor adjustments had to be made to be compatible with the most recent library versions.

With kind regards,
Andreas.