### PR TITLE
node-esp32-generic: Modernize PlatformIO dependencies

### DIFF
--- a/node-esp32-generic/platformio.ini
+++ b/node-esp32-generic/platformio.ini
@@ -18,12 +18,14 @@ framework = arduino
 
 monitor_speed = 115200
 
+lib_ldf_mode = deep+
+
 lib_deps =
-    TinyGSM@0.10.6
-    RunningMedian@0.1.15
-    OneWire@2.3.5
-    HX711@0.7.4
-    DallasTemperature@3.8.1
-    ArduinoJson@6.15.2
+    vshymanskyy/TinyGSM@^0.10.9
+    robtillaart/RunningMedian@^0.3.3
+    paulstoffregen/OneWire@^2.3.5
+    bogde/HX711@^0.7.4
+    milesburton/DallasTemperature@^3.9.1
+    bblanchon/ArduinoJson@^6
     https://github.com/tzapu/WiFiManager.git#development
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048


### PR DESCRIPTION
This patch modernizes the dependencies of the `node-esp32-generic` program.