### PR TITLE
Fix WifiManager dependency of "node-esp32-generic"

### DIFF
--- a/node-esp32-generic/platformio.ini
+++ b/node-esp32-generic/platformio.ini
@@ -27,5 +27,5 @@ lib_deps =
     bogde/HX711@^0.7.4
     milesburton/DallasTemperature@^3.9.1
     bblanchon/ArduinoJson@^6
-    https://github.com/tzapu/WiFiManager.git#development
+    https://github.com/tzapu/WiFiManager.git#a83ac6e
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048


### PR DESCRIPTION
This patch resolves #36. The code needed for ESP32-compatiblity is apparently not yet in `tzapu/WiFiManager@0.16.0`. So, while it is in `master` branch, we will use an explicit git ref here.