### PR TITLE
Migration to ArduinoJson 6

### DIFF
--- a/node-esp8266-generic/node-esp8266-generic.ino
+++ b/node-esp8266-generic/node-esp8266-generic.ino
@@ -50,6 +50,7 @@ Shield Lila
 //Version 1.20 Version um Tippfehler bereinigt und für Upload auf GitHub vorbereitet
 //Version 1.20 public - User / Login Credentials entfernt
 //Version 1.21 Modernisierung und PlatformIO Build-Umgebung
+//Version 1.22 Migration zu ArduinoJson 6
 
 
 #define GSM_ENABLED             false  // Bei FALSE wird automatisch WIFI aktiviert
@@ -785,13 +786,13 @@ void transmit_readings() {
 
   // Build JSON object containing sensor readings
   // TODO: How many data points actually fit into this?
-  StaticJsonBuffer<1024> jsonBuffer;
+  StaticJsonDocument<1024> jsonBuffer;
 
 
   // Create telemetry payload by manually mapping sensor readings to telemetry field names.
   // Note: For more advanced use cases, please have a look at the TerkinData C++ library
   //       https://hiveeyes.org/docs/arduino/TerkinData/README.html
-  JsonObject& json_data = jsonBuffer.createObject();
+  JsonObject json_data = jsonBuffer.to<JsonObject>();
 
   #if WUNDERGROUND
     json_data["WXD_Temp"]        = currentTemp;
@@ -820,13 +821,13 @@ void transmit_readings() {
   json_data["voltage"]           = voltage;
 
   // Debugging
-  json_data.printTo(Serial);
+  serializeJson(json_data, Serial);
 
 
   // Serialize data
-  int json_length = json_data.measureLength();
+  int json_length = measureJson(json_data);
   char payload[json_length + 1];
-  json_data.printTo(payload, sizeof(payload));
+  serializeJson(json_data, payload, sizeof(payload));
 
   // Publish data
   // TODO: Refactor to TerkinTelemetry

--- a/node-esp8266-generic/platformio.ini
+++ b/node-esp8266-generic/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
     HX711@0.7.4
     DallasTemperature@3.8.1
     RunningMedian@0.1.15
-    ArduinoJson@^5
+    ArduinoJson@^6
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048
     tzapu/WiFiManager@^0.16.0
     vshymanskyy/TinyGSM@^0.10.9


### PR DESCRIPTION
Migration to current version of ArdunioJson (v5 --> v6), see https://arduinojson.org/v6/doc/upgrade/.
Without these adjustments, the sketch does not compile with ArduinoJson v6.