### PR TITLE
Add CI configuration for most popular firmwares, and fix PlatformIO build recipes

### DIFF
--- a/.github/workflows/platformio-ci.yaml
+++ b/.github/workflows/platformio-ci.yaml
@@ -1,0 +1,72 @@
+name: PlatformIO CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.pio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+
+      - name: Install PlatformIO
+        run: |
+          pip install --upgrade --requirement requirements-test.txt
+
+      - name: Build scale-adjust / ADS1231
+        if: success() || failure()
+        run: |
+          pio run --project-dir scale-adjust/ADS1231
+
+      - name: Build scale-adjust / HX711
+        if: success() || failure()
+        run: |
+          pio run --project-dir scale-adjust/HX711
+
+      - name: Build node-gprs-http
+        if: success() || failure()
+        run: |
+          pio run --project-dir node-gprs-http
+
+      - name: Build node-wifi-mqtt
+        if: success() || failure()
+        run: |
+          pio run --project-dir node-wifi-mqtt
+
+      - name: Build node-esp8266-generic
+        if: success() || failure()
+        run: |
+          pio run --project-dir node-esp8266-generic
+
+      - name: Build node-esp32-generic
+        if: success() || failure()
+        run: |
+          pio run --project-dir node-esp32-generic

--- a/.github/workflows/platformio-ci.yaml
+++ b/.github/workflows/platformio-ci.yaml
@@ -3,8 +3,23 @@ name: PlatformIO CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/platformio-ci.yaml'
+      - 'scale-adjust/**'
+      - 'node-gprs-http/**'
+      - 'node-wifi-mqtt/**'
+      - 'node-esp8266-generic/**'
+      - 'node-esp32-generic/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/platformio-ci.yaml'
+      - 'scale-adjust/**'
+      - 'node-gprs-http/**'
+      - 'node-wifi-mqtt/**'
+      - 'node-esp8266-generic/**'
+      - 'node-esp32-generic/**'
+
   # Allow job to be triggered manually.
   workflow_dispatch:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -51,9 +51,6 @@
 [submodule "libraries/RobTillaart-Arduino"]
 	path = libraries/RobTillaart-Arduino
 	url = https://github.com/RobTillaart/Arduino
-[submodule "libraries/RobTillaart-libDHT"]
-	path = libraries/RobTillaart-libDHT
-	url = https://github.com/RobTillaart/libDHT
 [submodule "libraries/DS3231"]
 	path = libraries/DS3231
 	url = https://github.com/jcastaneyra/ds3231_library

--- a/libraries/RobTillaart-libDHT/.gitignore
+++ b/libraries/RobTillaart-libDHT/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/libraries/RobTillaart-libDHT/DHT.cpp
+++ b/libraries/RobTillaart-libDHT/DHT.cpp
@@ -1,0 +1,474 @@
+/*
+ * Name: libDHT
+ * License: MIT license.
+ * Location: https://github.com/ADiea/libDHT
+ * Maintainer: ADiea (https://github.com/ADiea)
+ *
+ * Descr: Arduino compatible DHT 11/22, AM2302 lib with dewpoint,
+ *        heat-index and other goodies.
+ *
+ * Features:
+ *  1. Autodetection of sensor type
+ *	2. Read humidity and temperature in one function call.
+ *	3. Determine heat index in *C or *F
+ *	4. Determine dewpoint with various algorithms(speed vs accuracy)
+ *	5. Determine thermal comfort
+ *		* Empiric comfort function based on comfort profiles
+ *		* Multiple comfort profiles. Default based on http://epb.apogee.net/res/refcomf.asp
+ *		* Determine if it's too cold, hot, humid, dry, based on current comfort profile
+ *
+ * History:
+ * x/xx/xx -----:	TODO: Comfort profiles
+ * 7/04/15 ADiea:	[experimental] comfort function; code reorganization; Autodetection;
+ * 7/02/15 ADiea:	dew point algorithms
+ * 6/25/15 ADiea: 	pullup option; read temp and humidity in one function call
+ *  	 	 	 	cache converted value for last temp and humid
+ * 6/20/15 cloned from https://github.com/adafruit/DHT-sensor-library
+ * -/--/-- written by Adafruit Industries
+ *
+ * License information:
+ *
+ * Copyright (c) 2015 ADiea
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include "DHT.h"
+
+void DHT::begin(void)
+{
+	//Pull the pin high to put the sensor in idle state
+	pinMode(m_kSensorPin, OUTPUT);
+	digitalWrite(m_kSensorPin, HIGH);
+
+	//Make sure the first read() will happen
+	m_lastreadtime = millis() - m_maxIntervalRead;
+
+	//Delay 250ms at least before the first read, so the sensor sees a stable
+	//pin HIGH output
+	delay(250);
+
+	/*Autodetect sensor*/
+	if(DHT_AUTO == m_kSensorType)
+	{
+		//set small wakeup to detect a DHT11 and start a read
+		m_wakeupTimeMs = WAKEUP_DHT22;
+		read();
+
+		/*If no timeout error, must be a DHT22 type sensor*/
+		if(m_lastError != errDHT_Timeout)
+		{
+			m_kSensorType = DHT22;
+			if (READ_INTERVAL_DONT_CARE == m_maxIntervalRead)
+			{
+				m_maxIntervalRead = READ_INTERVAL_DHT22_DSHEET;
+			}
+			m_wakeupTimeMs = WAKEUP_DHT22;
+			Serial.println("libDHT: Detected DHT-22 compatible sensor.");
+		}
+		else /* If sensor timedout it's probably a DHT11 */
+		{
+			m_kSensorType = DHT11;
+			if (READ_INTERVAL_DONT_CARE == m_maxIntervalRead)
+			{
+				m_maxIntervalRead = READ_INTERVAL_DHT11_DSHEET;
+			}
+			m_wakeupTimeMs = WAKEUP_DHT11;
+			Serial.println("libDHT: Detected DHT-11 compatible sensor.");
+		}
+	}
+}
+
+float DHT::readTemperature(bool bFarenheit/* = false*/)
+{
+	read();
+	if (NAN != m_lastTemp && bFarenheit)
+		return convertCtoF(m_lastTemp);
+	else
+		return m_lastTemp;
+}
+
+float DHT::readHumidity(void)
+{
+	read();
+	return m_lastHumid;
+}
+
+bool DHT::readTempAndHumidity(float* temp, float* humid, bool bFarenheit/* = false*/)
+{
+	bool bSuccess = false;
+
+	if (read())
+	{
+		if(temp)
+		{
+			*temp = m_lastTemp;
+			if(bFarenheit)
+			{
+				*temp = convertCtoF(*temp);
+			}
+		}
+		if(humid)
+		{
+			*humid = m_lastHumid;
+		}
+		bSuccess = true;
+	}
+	return bSuccess;
+}
+
+float DHT::getHeatIndexF(float tempFahrenheit, float percentHumidity)
+{
+// Adapted from equation at: https://github.com/adafruit/DHT-sensor-library/issues/9 and
+// Wikipedia: http://en.wikipedia.org/wiki/Heat_index
+	float t2F = tempFahrenheit * tempFahrenheit;
+	float h2 = percentHumidity * percentHumidity;
+
+	return -42.379 + 2.04901523 * tempFahrenheit + 10.14333127 * percentHumidity
+			+ -0.22475541 * tempFahrenheit * percentHumidity + -0.00683783 * t2F
+			+ -0.05481717 * h2 + 0.00122874 * t2F * percentHumidity
+			+ 0.00085282 * tempFahrenheit * h2 + -0.00000199 * t2F * h2;
+}
+
+float DHT::getHeatIndexC(float tempCelsius, float percentHumidity)
+{
+// Adapted from equation at: https://github.com/adafruit/DHT-sensor-library/issues/9 and
+// Wikipedia: http://en.wikipedia.org/wiki/Heat_index
+	float t2C = tempCelsius * tempCelsius;
+	float h2 = percentHumidity * percentHumidity;
+
+	return -8.784695 + 1.61139411 * tempCelsius + 2.33854900 * percentHumidity
+			+ -0.14611605 * tempCelsius * percentHumidity + -0.01230809 * t2C
+			+ -0.01642482 * h2 + 0.00221173 * t2C * percentHumidity
+			+ 0.00072546 * tempCelsius * h2 + -0.00000358 * t2C * h2;
+}
+
+double DHT::getDewPoint(float tempCelsius, float percentHumidity, uint8_t algType /*= DEW_ACCURATE_FAST*/)
+{
+	double result = NAN;
+	percentHumidity = percentHumidity * 0.01;
+
+	switch(algType)
+	{
+		/*xx/xx/xxxx; x.xxxms @ xxMhz; Accuracy xx.xx; Platform xxxxxxx; Samples xxxx */
+		/*Conclusion: */
+
+	    /*04/07/2015; 1.210ms @ 80Mhz; Accuracy +0.00; Platform ESP8266; Samples 2100 */
+		/*Conclusion: Accurate, resonably fast.
+		 *            Tested on a few samples against http://www.decatur.de/javascript/dew/ */
+		case DEW_ACCURATE:
+
+		{
+			/* 01/JUL/2015 ADiea: ported from FORTRAN http://wahiduddin.net/calc/density_algorithms.htm */
+			/*
+			FUNCTION ESGG(T)
+			Baker, Schlatter  17-MAY-1982     Original version.
+			THIS FUNCTION RETURNS THE SATURATION VAPOR PRESSURE OVER LIQUID
+			WATER ESGG (MILLIBARS) GIVEN THE TEMPERATURE T (CELSIUS). THE
+			FORMULA USED, DUE TO GOFF AND GRATCH, APPEARS ON P. 350 OF THE
+			SMITHSONIAN METEOROLOGICAL TABLES, SIXTH REVISED EDITION, 1963,
+			BY ROLAND LIST.
+			*/
+			double CTA = 273.15,  // DIFFERENCE BETWEEN KELVIN AND CELSIUS TEMPERATURES
+				   EWS = 3.00571489795, // log10 of SATURATION VAPOR PRESSURE (MB) OVER LIQUID WATER AT 100C
+				   TS = 373.15; // BOILING POINT OF WATER (K)
+
+			double  C1 = -7.90298, C2 = 5.02808, C3 = 1.3816E-7, C4 = 11.344, C5 = 8.1328E-3,  C6 = -3.49149;
+			tempCelsius = tempCelsius + CTA;
+			result = (TS / tempCelsius) - 1;
+
+			//   GOFF-GRATCH FORMULA
+
+			result = pow(10, (C1 * result + C2 * log10(result + 1) -
+						  C3 * (pow(10, (C4 * (1. - tempCelsius / TS))) - 1.) +
+						  C5 * (pow(10, (C6 * result)) - 1.) + EWS));
+			if(result < 0)
+				result = 0;
+			//result now holds the saturation vapor pressure in mBar
+			//	https://en.wikipedia.org/wiki/Vapor_pressure
+			//Convert from mBar to kPa (1mBar = 0.1 kPa) and divide by 0.61078 constant
+			//Determine vapor pressure (takes the RH into account)
+			//	http://www.colorado.edu/geography/weather_station/Geog_site/about.htm
+			result = percentHumidity * result / (10 * 0.61078);
+			result = log(result);
+			result =(241.88 * result) / (17.558 - result);
+		}
+		break;
+
+	    /*xx/xx/xxxx; x.xxxms @ xxMhz; Accuracy xx.xx; Platform xxxxxxx; Samples xxxx */
+		/*Conclusion: */
+
+	    /*04/07/2015; 0.522ms @ 80Mhz; Accuracy -0.001; Platform ESP8266; Samples 2100 */
+		/*Conclusion: Best choice, 0.001*C deviation with double speed */
+		case DEW_ACCURATE_FAST:
+
+		{
+			/*Saturation vapor pressure is calculated by the datalogger
+			 * with the following approximating polynomial
+			 * (see Lowe, P.R. 1930. J. Appl. Meteor., 16:100-103):
+			 * http://www.colorado.edu/geography/weather_station/Geog_site/about.htm
+			 */
+			result = 6.107799961 +
+						  tempCelsius * (0.4436518521 +
+						  tempCelsius * (0.01428945805 +
+						  tempCelsius * (2.650648471e-4 +
+						  tempCelsius * (3.031240396e-6 +
+						  tempCelsius * (2.034080948e-8 +
+						  tempCelsius * 6.136820929e-11)))));
+	        //Convert from mBar to kPa (1mBar = 0.1 kPa) and divide by 0.61078 constant
+	        //Determine vapor pressure (takes the RH into account)
+	        result = percentHumidity * result / (10 * 0.61078);
+			result = log(result);
+			result = (241.88 * result) / (17.558 - result);
+		}
+		break;
+
+	    /*xx/xx/xxxx; x.xxxms @ xxMhz; Accuracy xx.xx; Platform xxxxxxx; Samples xxxx */
+		/*Conclusion: */
+
+	    /*04/07/2015; 0.723ms @ 80Mhz; Accuracy -0.06; Platform ESP8266; Samples 2100 */
+		/*Conclusion: Worst choice. Very slow on this architecture, and inaccurate */
+		case DEW_FAST:
+		{
+			/* 01/JUL/2015 ADiea: ported from FORTRAN http://wahiduddin.net/calc/density_algorithms.htm */
+			/*
+				Baker, Schlatter  17-MAY-1982     Original version.
+				THIS FUNCTION RETURNS THE DEW POINT (CELSIUS) GIVEN THE TEMPERATURE
+				(CELSIUS) AND RELATIVE HUMIDITY (%). THE FORMULA IS USED IN THE
+				PROCESSING OF U.S. RAWINSONDE DATA AND IS REFERENCED IN PARRY, H.
+				DEAN, 1969: "THE SEMIAUTOMATIC COMPUTATION OF RAWINSONDES,"
+				TECHNICAL MEMORANDUM WBTM EDL 10, U.S. DEPARTMENT OF COMMERCE,
+				ENVIRONMENTAL SCIENCE SERVICES ADMINISTRATION, WEATHER BUREAU,
+				OFFICE OF SYSTEMS DEVELOPMENT, EQUIPMENT DEVELOPMENT LABORATORY,
+				SILVER SPRING, MD (OCTOBER), PAGE 9 AND PAGE II-4, LINE 460.
+			*/
+				result = 1. - percentHumidity;
+
+			/*  COMPUTE DEW POINT DEPRESSION. */
+				result = (14.55 + 0.114 * tempCelsius)*result +
+							 pow((2.5 + 0.007 * tempCelsius)*result, 3) +
+							 (15.9 + 0.117 * tempCelsius)*pow(result, 14);
+
+				result = tempCelsius - result;
+		}
+		break;
+
+	    /*xx/xx/xxxx; x.xxxms @ xxMhz; Accuracy xx.xx; Platform xxxxxxx; Samples xxxx */
+		/*Conclusion: */
+
+	    /*04/07/2015; 0.522ms @ 80Mhz; Accuracy +0.03; Platform ESP8266; Samples 2100 */
+		/*Conclusion: Bad choice. As fast as ACCURATEFAST but 30 times more inaccurate */
+		case DEW_FASTEST:
+		{
+			/* http://en.wikipedia.org/wiki/Dew_point */
+			double a = 17.271;
+			double b = 237.7;
+			result = (a * tempCelsius) / (b + tempCelsius) + log(percentHumidity);
+			result = (b * result) / (a - result);
+		}
+		break;
+	};
+
+	return result;
+}
+
+float DHT::getComfortRatio(float tCelsius, float humidity, ComfortState& comfort)
+{
+	float ratio = 100; //100%
+	float distance = 0;
+	float kTempFactor = 3; //take into account the slope of the lines
+	float kHumidFactor = 0.1; //take into account the slope of the lines
+	uint8_t tempComfort = 0;
+	
+	comfort = Comfort_OK;
+
+	distance = distanceTooHot(tCelsius, humidity);
+	if(distance > 0)
+	{
+		//update the comfort descriptor
+		tempComfort += (uint8_t)Comfort_TooHot;
+		//decrease the comfot ratio taking the distance into account
+		ratio -= distance * kTempFactor;
+	}
+	
+	distance = distanceTooHumid(tCelsius, humidity);
+	if(distance > 0)
+	{
+		//update the comfort descriptor
+		tempComfort += (uint8_t)Comfort_TooHumid;
+		//decrease the comfot ratio taking the distance into account
+		ratio -= distance * kHumidFactor;
+	}	
+	
+	distance = distanceTooCold(tCelsius, humidity);
+	if(distance > 0)
+	{
+		//update the comfort descriptor
+		tempComfort += (uint8_t)Comfort_TooCold;
+		//decrease the comfot ratio taking the distance into account
+		ratio -= distance * kTempFactor;
+	}
+
+	distance = distanceTooDry(tCelsius, humidity);
+	if(distance > 0)
+	{
+		//update the comfort descriptor
+		tempComfort += (uint8_t)Comfort_TooDry;
+		//decrease the comfot ratio taking the distance into account
+		ratio -= distance * kHumidFactor;
+	}
+
+	comfort = (ComfortState)tempComfort;
+
+	if(ratio < 0)
+		ratio = 0;
+
+	return ratio;
+}
+
+void DHT::updateInternalCache()
+{
+	/*Compute and write temp and humid to internal cache*/
+	switch (m_kSensorType)
+	{
+		case DHT11:
+			m_lastTemp = m_data[2];
+			m_lastHumid = m_data[0];
+			break;
+		case DHT22:
+		case DHT21:
+			/*Temp*/
+			m_lastTemp = ((uint32_t)(m_data[2] & 0x7F)<<8 | m_data[3]) / 10.0f;
+			if (m_data[2] & 0x80)
+			{
+				m_lastTemp = -m_lastTemp;
+			}
+			/*Humidity*/
+			m_lastHumid = (((uint32_t)m_data[0])<<8 | m_data[1]) / 10.0f;
+			break;
+		default:
+			Serial.println("libDHT: Unknown sensor type");
+			break;
+	}
+}
+
+bool DHT::read(void)
+{
+	uint8_t laststate = HIGH;
+	uint8_t counter = 0;
+	uint8_t j = 0, i;
+	unsigned long time = millis();
+
+	//Determine if it's appropiate to read the sensor, or return data from cache
+	if ((time - m_lastreadtime) < m_maxIntervalRead && (errDHT_OK == m_lastError))
+	{
+		return true; // will use last data from cache
+	}
+	m_lastreadtime = time;
+
+	//reset internal data and invalidate cache
+	m_data[0] = m_data[1] = m_data[2] = m_data[3] = m_data[4] = 0;
+	m_lastError = errDHT_Other;
+	m_lastTemp = NAN;
+	m_lastHumid = NAN;
+
+	//Pull the pin low for m_wakeupTimeMs milliseconds
+	pinMode(m_kSensorPin, OUTPUT);
+	digitalWrite(m_kSensorPin, LOW);
+	delay(m_wakeupTimeMs);
+	//clear interrupts
+	cli();
+	//Make pin input and activate pullup
+	pinMode(m_kSensorPin, INPUT);
+	if (m_bPullupEnabled)
+	{
+		pullup(m_kSensorPin);
+	}
+	else
+	{
+		digitalWrite(m_kSensorPin, HIGH);
+	}
+
+	//Read in the transitions
+	for (i = 0; i < MAXTIMINGS || j >= 40; i++)
+	{
+		counter = 0;
+		while (digitalRead(m_kSensorPin) == laststate)
+		{
+			counter++;
+			delayMicroseconds(1);
+			if (counter == 255)
+			{
+				break;
+			}
+		}
+		laststate = digitalRead(m_kSensorPin);
+
+		if (counter == 255)
+		{
+			m_lastError = errDHT_Timeout;
+			break;
+		}
+
+		// ignore first 3 transitions
+		if ((i >= 4) && (i % 2 == 0))
+		{
+			// shove each bit into the storage bytes
+			m_data[j / 8] <<= 1;
+
+			if (counter > ONE_DURATION_THRESH_US)
+			{
+				m_data[j / 8] |= 1;
+			}
+			j++;
+		}
+	}
+	sei();
+
+#if DHT_DEBUG
+	 Serial.println(j, DEC);
+	 Serial.print(m_data[0], HEX); Serial.print(", ");
+	 Serial.print(m_data[1], HEX); Serial.print(", ");
+	 Serial.print(m_data[2], HEX); Serial.print(", ");
+	 Serial.print(m_data[3], HEX); Serial.print(", ");
+	 Serial.print(m_data[4], HEX); Serial.print(" =? ");
+	 Serial.println((m_data[0] + m_data[1] + m_data[2] + m_data[3]) & 0xFF, HEX);
+#endif
+
+	// pull the pin high at the end
+	 //(will stay high at least 250ms until the next reading)
+	pinMode(m_kSensorPin, OUTPUT);
+	digitalWrite(m_kSensorPin, HIGH);
+
+	// check we read 40 bits and that the checksum matches
+	if ((j >= 40) &&
+	    (m_data[4] == ((m_data[0] + m_data[1] + m_data[2] + m_data[3]) & 0xFF)))
+	{
+		updateInternalCache();
+		m_lastError = errDHT_OK;
+		return true;
+	}
+	else
+	{
+		m_lastError = errDHT_Checksum;
+	}
+
+	return false;
+}

--- a/libraries/RobTillaart-libDHT/DHT.h
+++ b/libraries/RobTillaart-libDHT/DHT.h
@@ -1,0 +1,190 @@
+/*
+ * Name: libDHT
+ * License: MIT license. See details in DHT.cpp.
+ * Location: https://github.com/ADiea/libDHT
+ * Maintainer: ADiea (https://github.com/ADiea)
+ *
+ * Descr: Arduino compatible DHT 11/22, AM2302 lib with dewpoint,
+ *        heat-index and other goodies.
+ *
+ * Features & History:
+ * See DHT.cpp
+ */
+
+#ifndef DHT_H
+#define DHT_H
+#if ARDUINO >= 100
+ #include "Arduino.h"
+#else
+ #include "WProgram.h"
+#endif
+
+#define DHT_DEBUG 0 //Change to 1 for debug output
+
+/*From datasheet: http://www.micro4you.com/files/sensor/DHT11.pdf
+ * '0' if HIGH lasts 26-28us,
+ * '1' if HIGH lasts 70us
+ */
+#define ONE_DURATION_THRESH_US 30
+
+#define DHTLIB_DHT11_WAKEUP         18
+#define DHTLIB_DHT22_WAKEUP         5
+
+// how many timing transitions we need to keep track of. 2 * number bits + extra
+#define MAXTIMINGS 85
+
+#define DHT_AUTO 0
+#define DHT11 11
+#define DHT22 22
+#define DHT21 21
+#define AM2301 21
+
+#define READ_INTERVAL_DHT11_DSHEET 1000
+#define READ_INTERVAL_DHT22_DSHEET 2000
+#define READ_INTERVAL_DONT_CARE 2200 /*safe value*/
+#define READ_INTERVAL_LONG 4000
+
+#define DEW_ACCURATE 0
+#define DEW_FAST 1
+#define DEW_ACCURATE_FAST 2
+#define DEW_FASTEST 3
+
+#define WAKEUP_DHT11 18
+#define WAKEUP_DHT22 1
+
+// Reference: http://epb.apogee.net/res/refcomf.asp
+enum ComfortState
+{
+	Comfort_OK = 0,
+	Comfort_TooHot = 1,
+	Comfort_TooCold = 2,
+	Comfort_TooDry = 4,
+	Comfort_TooHumid = 8,
+	Comfort_HotAndHumid = 9,
+	Comfort_HotAndDry = 5,
+	Comfort_ColdAndHumid = 10,
+	Comfort_ColdAndDry = 6
+};
+
+enum ErrorDHT
+{
+	errDHT_OK = 0,
+	errDHT_Timeout,
+	errDHT_Checksum,
+	errDHT_Other,
+};
+
+class DHT
+{
+public:
+	DHT(uint8_t pin, uint8_t type = DHT_AUTO, boolean pullup = false,
+			uint16_t maxIntervalRead = READ_INTERVAL_DONT_CARE)
+		: m_kSensorPin(pin), m_kSensorType(type),
+		  m_bPullupEnabled(pullup), m_lastreadtime(0), m_maxIntervalRead(maxIntervalRead)
+	{
+		m_lastError = errDHT_Other;
+		m_lastTemp = NAN;
+		m_lastHumid = NAN;
+
+		if (DHT11 == m_kSensorType)
+		{
+			if (READ_INTERVAL_DONT_CARE == maxIntervalRead)
+			{
+				m_maxIntervalRead = READ_INTERVAL_DHT11_DSHEET;
+			}
+			m_wakeupTimeMs = WAKEUP_DHT11;
+		}
+		else if (DHT22 == m_kSensorType || DHT21 == m_kSensorType)
+		{
+			if (READ_INTERVAL_DONT_CARE == maxIntervalRead)
+			{
+				m_maxIntervalRead = READ_INTERVAL_DHT22_DSHEET;
+			}
+			m_wakeupTimeMs = WAKEUP_DHT22;
+		}
+
+		//In computing these constants the following reference was used
+		//http://epb.apogee.net/res/refcomf.asp
+		//It was simplified as 4 straight lines and added very little skew on
+		//the vertical lines (+0.1 on x for C,D)
+		//The for points used are(from top left, clock wise)
+		//A(30%, 30*C) B(70%, 26.2*C) C(70.1%, 20.55*C) D(30.1%, 22.22*C)
+		//On the X axis we have the rel humidity in % and on the Y axis the temperature in *C
+
+		//Too hot line AB
+		m_tooHot_m = -0.095;
+		m_tooHot_b = 32.85;
+		//Too humid line BC
+		m_tooHumid_m =  -56.5;
+		m_tooHumid_b = 3981.2;
+		//Too cold line DC
+		m_tooCold_m = -0.04175;
+		m_tooHCold_b = 23.476675;
+		//Too dry line AD
+		m_tooDry_m = -77.8;
+		m_tooDry_b = 2364;
+	};
+
+	void begin(void);
+
+	float readTemperature(bool bFarenheit = false);
+	float readHumidity(void);
+	bool readTempAndHumidity(float* temp, float* humid, bool bFarenheit = false);
+
+	inline float convertCtoF(float c){ return c * 1.8f + 32; }
+	inline float convertFtoC(float f){ return (f-32)/1.8f; }
+
+	float getHeatIndexC(float tempCelsius, float percentHumidity);
+	float getHeatIndexF(float tempFahrenheit, float percentHumidity);
+	double getDewPoint(float tempCelsius, float percentHumidity,
+			uint8_t algType = DEW_ACCURATE_FAST);
+
+	float getComfortRatio(float tCelsius, float humidity, ComfortState& comfort);
+
+	inline bool isTooHot(float tCelsius, float humidity)
+		{return (tCelsius > (humidity * m_tooHot_m + m_tooHot_b));}
+	inline bool isTooHumid(float tCelsius, float humidity)
+		{return (tCelsius > (humidity * m_tooHumid_m + m_tooHumid_b));}
+	inline bool isTooCold(float tCelsius, float humidity)
+		{return (tCelsius < (humidity * m_tooCold_m + m_tooHCold_b));}
+	inline bool isTooDry(float tCelsius, float humidity)
+		{return (tCelsius < (humidity * m_tooDry_m + m_tooDry_b));}
+
+	inline ErrorDHT getm_lastError() { return m_lastError; }
+private:
+	bool read(void);
+	void updateInternalCache();
+	
+	inline float distanceTooHot(float tCelsius, float humidity)
+		{return tCelsius - (humidity * m_tooHot_m + m_tooHot_b);}
+	inline float distanceTooHumid(float tCelsius, float humidity)
+		{return tCelsius - (humidity * m_tooHumid_m + m_tooHumid_b);}
+	inline float distanceTooCold(float tCelsius, float humidity)
+		{return (humidity * m_tooCold_m + m_tooHCold_b) - tCelsius;}
+	inline float distanceTooDry(float tCelsius, float humidity)
+		{return (humidity * m_tooDry_m + m_tooDry_b) - tCelsius;}	
+	
+	uint8_t m_kSensorPin, m_kSensorType;
+	uint8_t m_data[6];
+	unsigned long m_lastreadtime;
+	uint8_t m_wakeupTimeMs;
+
+	boolean m_bPullupEnabled;
+	ErrorDHT m_lastError;
+
+	//The datasheet advises to read no more than one every 2 seconds.
+	//However if reads are done at greater intervals the sensor's output
+	//will be less subject to self-heating
+	//Reference: http://www.kandrsmith.org/RJS/Misc/dht_sht_how_fast.html
+	uint16_t m_maxIntervalRead;
+
+	//Represent the 4 line equations:
+	//dry, humid, hot, cold, using the y = mx + b formula
+	float m_tooHot_m, m_tooHot_b;
+	float m_tooCold_m, m_tooHCold_b;
+	float m_tooDry_m, m_tooDry_b;
+	float m_tooHumid_m, m_tooHumid_b;
+
+	float m_lastTemp, m_lastHumid;
+};
+#endif

--- a/libraries/RobTillaart-libDHT/LICENSE
+++ b/libraries/RobTillaart-libDHT/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 ADiea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/libraries/RobTillaart-libDHT/README.md
+++ b/libraries/RobTillaart-libDHT/README.md
@@ -1,0 +1,41 @@
+# libDHT - yet another DHT lib
+Arduino compatible DHT 11/22, AM2302 lib with dewpoint, heat-index and other goodies. 
+
+##Features
+
+1. Autodetection of sensor type
+2. Read humidity and temperature in one function call.
+3. Determine heat index in *C or *F
+4. Determine dewpoint with various algorithms(speed vs accuracy)
+5. Determine thermal comfort
+  * Empiric comfort function based on comfort profiles
+  * (TODO) Multiple comfort profiles. Default based on http://epb.apogee.net/res/refcomf.asp
+  * Determine if it's too cold, hot, humid, dry, based on current comfort profile
+6. Optimized for sensor read speed(~5ms for DHT22), stack and code size.
+
+## Tested on
+
+| Platform | 				SensorReading*) (ms) | 	DewPoint Accurate-Fast (ms) |
+|:--------:|:--------------------------------:|:------------------------------:|
+| ESP8266-ESP12 @ 80Mhz |	5.6 (DHT22) |					0.5  |
+
+*)Sensor reading speed should be independent of CPU speed
+
+*If you can help with testing on various Arduino platforms or various sensor types, open an issue and let me know.*
+
+## Credits
+
+Based on *DHT-sensor-library* https://github.com/adafruit/DHT-sensor-library
+
+Based on *arduino-DHT* https://github.com/markruys/arduino-DHT
+
+Based on *DHTlib* https://github.com/RobTillaart/Arduino/tree/master/libraries/DHTlib
+
+Used *Sming Framework* for the ESP8266 platform https://github.com/anakod/Sming
+
+## Disclaimer
+
+**This was tested on an ESP8266 module(ESP-12) running at 80Mhz.**
+
+**_This is in theory compatible with Arduino but untested yet_**
+

--- a/node-esp32-generic/Makefile
+++ b/node-esp32-generic/Makefile
@@ -1,4 +1,4 @@
-$(eval venvpath  := .venv3)
+$(eval venvpath  := .venv)
 $(eval python    := $(venvpath)/bin/python)
 $(eval pip       := $(venvpath)/bin/pip)
 $(eval pio       := $(venvpath)/bin/pio)
@@ -11,5 +11,5 @@ upload: setup-virtualenv
 	$(pio) run --target upload --upload-port=${MCU_PORT}
 
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	@test -e $(python) || python3 -m venv $(venvpath)
 	$(pip) install platformio

--- a/node-esp32-generic/platformio.ini
+++ b/node-esp32-generic/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:ttgo-t1]
-platform = espressif32
+platform = espressif32@^2
 board = ttgo-t1
 framework = arduino
 
@@ -22,10 +22,10 @@ lib_ldf_mode = deep+
 
 lib_deps =
     vshymanskyy/TinyGSM@^0.10.9
-    robtillaart/RunningMedian@^0.3.3
+    robtillaart/RunningMedian@0.3.7
     paulstoffregen/OneWire@^2.3.5
-    bogde/HX711@^0.7.4
+    bogde/HX711@0.7.4
     milesburton/DallasTemperature@^3.9.1
     bblanchon/ArduinoJson@^6
-    https://github.com/tzapu/WiFiManager.git#a83ac6e
+    https://github.com/tzapu/WiFiManager.git#2.0.4-beta
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048

--- a/node-esp8266-generic/Makefile
+++ b/node-esp8266-generic/Makefile
@@ -11,5 +11,5 @@ upload: setup-virtualenv
 	$(pio) run --target upload --upload-port=${MCU_PORT}
 
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	@test -e $(python) || python3 -m venv $(venvpath)
 	$(pip) install platformio

--- a/node-esp8266-generic/platformio.ini
+++ b/node-esp8266-generic/platformio.ini
@@ -12,19 +12,19 @@
 src_dir = .
 
 [env:nodemcu]
-platform = espressif8266
+platform = espressif8266@^2
 board = nodemcuv2
 framework = arduino
 
 monitor_speed = 115200
 
 lib_deps =
-    OneWire@2.3.5
-    HX711@0.7.4
+    paulstoffregen/OneWire@2.3.5
+    bogde/HX711@0.7.4
     DallasTemperature@3.8.1
-    RunningMedian@0.1.15
+    robtillaart/RunningMedian@0.3.7
     ArduinoJson@^6
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048
     tzapu/WiFiManager@^0.16.0
     vshymanskyy/TinyGSM@^0.10.9
-    tardate/TextFinder
+    https://github.com/hiveeyes/TextFinder#modernize

--- a/node-gprs-http/platformio.ini
+++ b/node-gprs-http/platformio.ini
@@ -15,12 +15,12 @@ monitor_speed = 115200
 
 [common]
 lib_deps =
-    paulstoffregen/OneWire@^2.3.5
-    bogde/HX711@^0.7.4
+    paulstoffregen/OneWire@2.3.5
+    bogde/HX711@0.7.4
     ../libraries/ADS1231
     milesburton/DallasTemperature@^3.9.1
     robtillaart/DHTStable@^0.2.9
-    robtillaart/RunningMedian@^0.3.3
+    robtillaart/RunningMedian@0.3.7
     ../libraries/DS3231
 
 [env:atmega328p]
@@ -33,7 +33,7 @@ lib_deps =
     rocketscream/Low-Power@^1.6
 
 [env:nodemcu]
-platform = espressif8266
+platform = espressif8266@^2
 board = nodemcuv2
 framework = arduino
 lib_deps =

--- a/node-wifi-mqtt-homie-battery/platformio.ini
+++ b/node-wifi-mqtt-homie-battery/platformio.ini
@@ -21,6 +21,6 @@ monitor_speed = 115200
 lib_deps =
     marvinroger/Homie@^2
     paulstoffregen/OneWire@^2.3.5
-    bogde/HX711@^0.7.4
+    bogde/HX711@0.7.4
     milesburton/DallasTemperature@^3.9.1
-    robtillaart/RunningMedian@^0.3.3
+    robtillaart/RunningMedian@0.3.7

--- a/node-wifi-mqtt-homie-calibration/platformio.ini
+++ b/node-wifi-mqtt-homie-calibration/platformio.ini
@@ -21,6 +21,6 @@ monitor_speed = 115200
 lib_deps =
     marvinroger/Homie@^2
     paulstoffregen/OneWire@^2.3.5
-    bogde/HX711@^0.7.4
+    bogde/HX711@0.7.4
     milesburton/DallasTemperature@^3.9.1
-    robtillaart/RunningMedian@^0.3.3
+    robtillaart/RunningMedian@0.3.7

--- a/node-wifi-mqtt-homie/platformio.ini
+++ b/node-wifi-mqtt-homie/platformio.ini
@@ -21,6 +21,6 @@ monitor_speed = 115200
 lib_deps =
     marvinroger/Homie@^2
     paulstoffregen/OneWire@^2.3.5
-    bogde/HX711@^0.7.4
+    bogde/HX711@0.7.4
     milesburton/DallasTemperature@^3.9.1
     robtillaart/RunningMedian@^0.3.3

--- a/node-wifi-mqtt/Makefile
+++ b/node-wifi-mqtt/Makefile
@@ -11,5 +11,5 @@ upload: setup-virtualenv
 	$(pio) run --target upload --upload-port=${MCU_PORT}
 
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	@test -e $(python) || python3 -m venv $(venvpath)
 	$(pip) install platformio

--- a/node-wifi-mqtt/platformio.ini
+++ b/node-wifi-mqtt/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:huzzah]
-platform = espressif8266
+platform = espressif8266@^2
 board = huzzah
 framework = arduino
 
@@ -20,11 +20,11 @@ monitor_speed = 115200
 
 lib_deps =
     joaolopesf/SerialDebug@^0.9.82
-    OneWire@2.3.5
-    HX711@0.7.4
+    paulstoffregen/OneWire@2.3.5
+    bogde/HX711@0.7.4
     DallasTemperature@3.8.1
     robtillaart/DHTStable@^0.2.9
     ../libraries/ADS1231
-    RunningMedian@0.1.15
+    robtillaart/RunningMedian@0.3.7
     ArduinoJson@^5
     https://github.com/daq-tools/Adafruit_MQTT_Library#maxbuffersize-2048

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+#ino==0.3.6
+platformio<7

--- a/scale-adjust/ADS1231/Makefile
+++ b/scale-adjust/ADS1231/Makefile
@@ -11,5 +11,5 @@ upload: setup-virtualenv
 	$(pio) run --target upload --upload-port=${MCU_PORT}
 
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	@test -e $(python) || python3 -m venv $(venvpath)
 	$(pip) install platformio

--- a/scale-adjust/ADS1231/platformio.ini
+++ b/scale-adjust/ADS1231/platformio.ini
@@ -16,7 +16,7 @@ monitor_speed = 115200
 [common]
 lib_deps =
     ../../libraries/ADS1231
-    robtillaart/RunningMedian@^0.3.3
+    robtillaart/RunningMedian@0.3.7
 
 [env:atmega328p]
 platform = atmelavr
@@ -26,7 +26,7 @@ lib_deps =
     ${common.lib_deps}
 
 [env:nodemcu]
-platform = espressif8266
+platform = espressif8266@^2
 board = nodemcuv2
 framework = arduino
 lib_deps =

--- a/scale-adjust/HX711/Makefile
+++ b/scale-adjust/HX711/Makefile
@@ -11,5 +11,5 @@ upload: setup-virtualenv
 	$(pio) run --target upload --upload-port=${MCU_PORT}
 
 setup-virtualenv:
-	@test -e $(python) || `command -v virtualenv` --python=python3 $(venvpath)
+	@test -e $(python) || python3 -m venv $(venvpath)
 	$(pip) install platformio

--- a/scale-adjust/HX711/platformio.ini
+++ b/scale-adjust/HX711/platformio.ini
@@ -15,8 +15,8 @@ monitor_speed = 115200
 
 [common]
 lib_deps =
-    bogde/HX711@^0.7.4
-    robtillaart/RunningMedian@^0.3.3
+    bogde/HX711@0.7.4
+    robtillaart/RunningMedian@0.3.7
 
 [env:atmega328p]
 platform = atmelavr
@@ -26,14 +26,14 @@ lib_deps =
     ${common.lib_deps}
 
 [env:nodemcu]
-platform = espressif8266
+platform = espressif8266@^2
 board = nodemcuv2
 framework = arduino
 lib_deps =
     ${common.lib_deps}
 
 [env:ttgo-t1]
-platform = espressif32
+platform = espressif32@^1
 board = ttgo-t1
 framework = arduino
 lib_deps =


### PR DESCRIPTION
Hi there,

in order to improve the quality of our most popular firmwares hosted in this repository, this patch brings a few PlatformIO configuration files up to speed, and adds a CI configuration using GitHub Actions.

The most important topics are:

- https://github.com/RobTillaart/libDHT ceased to exist, so its original content replaced the previous Git submodule linking.
- Explicitly use `platform` tags `espressif32@^2` and `espressif8266@^2`.
- Explicitly use `bogde/HX711@0.7.4`, because the 0.7.5 release might have a flaw on Espressif chips (ESP32 & ESP8266), see https://github.com/bogde/HX711/issues/222.
- Update to `robtillaart/RunningMedian@0.3.7`.
- `tardate/TextFinder` needed a fix to mitigate compilation errors. So, use `https://github.com/hiveeyes/TextFinder#modernize`, until https://github.com/tardate/TextFinder/pull/4 has been merged and released.

With those adjustments, the firmwares `scale-adjust/ADS1231`, `scale-adjust/HX711`, `node-gprs-http`, `node-wifi-mqtt`, `node-esp8266-generic`, and `node-esp32-generic`, build successfully on CI.

![image](https://github.com/hiveeyes/arduino/assets/453543/e8531524-8947-4f26-9cd1-19293df0fcff)

Let me know if you have any further suggestions on this topic.

With kind regards,
Andreas.

/cc @msweef