### PR TITLE
Dependencies: Use most recent version of ESP32 platform SDK

### DIFF
--- a/openhive/scale-adjust/HX711/platformio.ini
+++ b/openhive/scale-adjust/HX711/platformio.ini
@@ -27,6 +27,6 @@ board = nodemcuv2
 framework = arduino
 
 [env:ttgo-t1]
-platform = espressif32@^1
+platform = espressif32
 board = ttgo-t1
 framework = arduino

--- a/ringlabs/bienenwaage-5.0/platformio.ini
+++ b/ringlabs/bienenwaage-5.0/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:ttgo-t1]
-platform = espressif32@^2
+platform = espressif32
 board = ttgo-t1
 framework = arduino
 


### PR DESCRIPTION
As suggested at https://github.com/hiveeyes/arduino/issues/58#issuecomment-1567230794, this patch intends to use the most recent version of the ESP32 platform SDK.