### PR TITLE
Dependencies: Use most recent version of AVR platform SDK. Dissolve custom StandardCplusplus fork.

### DIFF
--- a/backdoor/multihop/multihop.ino
+++ b/backdoor/multihop/multihop.ino
@@ -126,9 +126,7 @@ The firmware serves different purposes, you can configure it as a Â»sensor nodeÂ
     #include <Arduino.h>
 
     // Standard C++ for Arduino
-    #include <new.cpp>
-    #include <StandardCplusplus.h>
-    #include <func_exception.cpp>
+    #include <ArduinoSTL.h>
     #include <MemoryFree.h>
 
 #endif

--- a/backdoor/multihop/platformio.ini
+++ b/backdoor/multihop/platformio.ini
@@ -18,7 +18,7 @@ framework = arduino
 lib_deps =
     apechinsky/MemoryFree@^0.3
     mikem/RadioHead@^1.120
-    https://github.com/hiveeyes/StandardCplusplus#next
+    mike-matera/ArduinoSTL@^1
     ../../libraries/Terrine
 build_flags =
     -fdiagnostics-color
@@ -54,6 +54,7 @@ board = pro8MHzatmega328
 lib_deps =
     ${env.lib_deps}
     ${node-common.lib_deps}
+    lowpowerlab/SPIFlash@^101
     lowpowerlab/RFM69@^1.5
 build_flags =
     ${env.build_flags}

--- a/backdoor/multihop/platformio.ini
+++ b/backdoor/multihop/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env]
-platform = atmelavr@^2
+platform = atmelavr
 board = pro8MHzatmega328
 framework = arduino
 lib_deps =

--- a/backdoor/node-rfm69-beradio/platformio.ini
+++ b/backdoor/node-rfm69-beradio/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:atmega328]
-platform = atmelavr@^2
+platform = atmelavr
 board = pro8MHzatmega328
 framework = arduino
 lib_deps =

--- a/openhive/rfm69-node/platformio.ini
+++ b/openhive/rfm69-node/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 
 [env:atmega328]
-platform = atmelavr@^2
+platform = atmelavr
 board = pro8MHzatmega328
 framework = arduino
 lib_deps =


### PR DESCRIPTION
As suggested at https://github.com/hiveeyes/arduino/issues/58#issuecomment-1567230794, this patch intends to use the most recent version of the AVR platform SDK. After failing on it first, it turns out the solution is to get rid of the custom `StandardCplusplus` fork we have been using here, and choose `ArduinoSTL` instead. 💯 