### PR TITLE
[Mois Labs] Update code to use 2022 version. Use SHT30 instead of DHT22.

### DIFF
--- a/doc/source/firmware/overview.md
+++ b/doc/source/firmware/overview.md
@@ -57,7 +57,7 @@ Running the [Mois Box], transmitting sensor data over HTTP, using the
 :columns: 4
 {bdg-primary-line}`eth` {bdg-primary-line}`wifi` {bdg-primary-line}`mqtt` {bdg-primary-line}`http` {bdg-primary-line}`json`
 
-{bdg-success-line}`ads1231` {bdg-success-line}`ds18b20` {bdg-success-line}`dht22` {bdg-success-line}`tsl2591`
+{bdg-success-line}`ads1231` {bdg-success-line}`ds18b20` {bdg-success-line}`sht30` {bdg-success-line}`tsl2591`
 
 {bdg-secondary-line}`ATmega328` {bdg-secondary-line}`arm`
 :::

--- a/doc/source/resources-md.md
+++ b/doc/source/resources-md.md
@@ -61,6 +61,7 @@
 [RHT04]: http://www.humiditycn.com/cp21.html
 [TSL25911]: https://ams.com/tsl25911
 [Adafruit TSL2591 STEMMA QT]: https://www.adafruit.com/product/1980
+[SHT30]: https://sensirion.com/products/catalog/SHT30-DIS-B
 [LowPowerLab]: https://lowpowerlab.com/
 [RFM69 based sensors and MQTT gateway]: https://github.com/computourist/RFM69-MQTT-client
 [Bencode]: https://en.wikipedia.org/wiki/Bencode

--- a/doc/source/resources.rst
+++ b/doc/source/resources.rst
@@ -121,6 +121,7 @@
 .. _RHT04: http://www.humiditycn.com/cp21.html
 .. _TSL25911: https://ams.com/tsl25911
 .. _Adafruit TSL2591 STEMMA QT: https://www.adafruit.com/product/1980
+.. _SHT30: https://sensirion.com/products/catalog/SHT30-DIS-B
 
 .. LowPowerLab and computourist
 .. _LowPowerLab: https://lowpowerlab.com/

--- a/moislabs/beescale-yun/README.rst
+++ b/moislabs/beescale-yun/README.rst
@@ -79,7 +79,7 @@ Sensors
 =======
 - ADS1231_ ADC weigh scale breakout board
 - DS18B20_ digital thermometer
-- DHT22_ (RHT03_) digital humidity/temperature sensor
+- `SHT30`_ digital humidity/temperature sensor
 - `TSL25911`_ Ambient Light Sensor aka.
   `Adafruit TSL2591 STEMMA QT`_ High Dynamic Range Digital Light Sensor
 

--- a/moislabs/beescale-yun/platformio.ini
+++ b/moislabs/beescale-yun/platformio.ini
@@ -8,13 +8,13 @@ src_dir = .
 
 [env]
 lib_deps =
-    adafruit/Adafruit TSL2591 Library@1.4.3
-    adafruit/DHT sensor library@1.4.4
-    arduino-libraries/Bridge@1.7.0
-    milesburton/DallasTemperature@3.11.0
-    paulstoffregen/OneWire@2.3.5
-    robtillaart/RunningMedian@0.3.7
-    watterott/digitalWriteFast@1.0.0
+    adafruit/Adafruit SHT31 Library@^2.2
+    adafruit/Adafruit TSL2591 Library@^1.4
+    arduino-libraries/Bridge@^1.7
+    milesburton/DallasTemperature@^3.11
+    paulstoffregen/OneWire@^2.3
+    robtillaart/RunningMedian@^0.3
+    watterott/digitalWriteFast@^1
     https://github.com/hiveeyes/aerowind-ads1231@^0.1.0
 
 [env:uno]


### PR DESCRIPTION
## About
This patch imports the current code [beescale-yun-2022.ino](https://github.com/bee-mois/beescale/blob/master/beescale-yun-2022.ino), after reformatting it.

