### PR TITLE
[TerkinTelemetry] Add transmitter component for CrateDB

### DIFF
--- a/libraries/TerkinTelemetry/TerkinTelemetry.h
+++ b/libraries/TerkinTelemetry/TerkinTelemetry.h
@@ -41,6 +41,7 @@ namespace Terkin {
     class TelemetryClient;
 
     // Forward declarations: Transmitters.
+    class CrateDBTransmitter;
     class JsonHttpTransmitter;
 
 
@@ -87,11 +88,13 @@ namespace Terkin {
 
     enum TransmitterType {
         DUMMY = 0,
+        CRATEDB,
         JSON_HTTP
     };
 
     class TelemetryClient {
         public:
+            TelemetryClient(CrateDBTransmitter* transmitter, ChannelAddress* address);
             TelemetryClient(JsonHttpTransmitter* transmitter, ChannelAddress* address);
             bool transmit(JsonObject& data);
             bool transmit(TerkinData::Measurement data);
@@ -117,6 +120,18 @@ namespace Terkin {
      * TODO: For wiring the GPRSbee, we currently use JSON,
      *       let's also aim at BERadio.
     **/
+
+    class CrateDBTransmitter {
+    public:
+        CrateDBTransmitter(const char *url, const char *username, const char *password);
+        ~CrateDBTransmitter() = default;
+        bool transmit(const char *database, const char *table, JsonObject& data);
+        bool transmit(const char *database, const char *table, TerkinData::Measurement data);
+    protected:
+        const char *_url;
+        const char *_username;
+        const char *_password;
+    };
 
     class JsonHttpTransmitter {
     public:

--- a/libraries/TerkinTelemetry/examples/Makefile
+++ b/libraries/TerkinTelemetry/examples/Makefile
@@ -25,7 +25,7 @@ all: setup-virtualenv run build
 run: posix-run
 
 # Run all POSIX program examples.
-posix-run: http-kotori
+posix-run: http-cratedb http-kotori
 
 
 # ==================================================
@@ -33,6 +33,7 @@ posix-run: http-kotori
 # ==================================================
 
 build: setup-virtualenv
+	$(MAKE) build-generic NAME=http-cratedb
 	$(MAKE) build-generic NAME=http-kotori
 
 .PHONY: build-generic
@@ -43,6 +44,10 @@ build-generic:
 # =========================================
 # Build and run individual examples (POSIX)
 # =========================================
+
+.PHONY: http-cratedb
+http-cratedb:
+	$(MAKE) generic NAME=$@
 
 .PHONY: http-kotori
 http-kotori:

--- a/libraries/TerkinTelemetry/examples/http-cratedb/config.h
+++ b/libraries/TerkinTelemetry/examples/http-cratedb/config.h
@@ -1,0 +1,42 @@
+// ******************************************
+//             User configuration
+// ******************************************
+
+// Connectivity
+// ============
+
+// Network
+// -------
+// TODO: For example, provide configuration settings for Wi-Fi connectivity.
+
+// Telemetry
+// ---------
+#define CRATEDB_URL         "http://localhost:4200/"
+#define CRATEDB_USERNAME    "crate"
+#define CRATEDB_PASSWORD    ""
+
+#define CHANNEL_REALM       "mqttkit-1"
+#define CHANNEL_OWNER       "testdrive"
+#define CHANNEL_SITE        "area-42"
+#define CHANNEL_DEVICE      "pipa-telemetry-http-cratedb"
+
+// Sensors
+// =======
+
+// TODO: No sensors yet. This is just a telemetry demo program.
+
+
+// ******************************************
+//           Developer configuration
+// ******************************************
+
+// Debugging
+// ---------
+/*
+#define DEBUG
+#define DEBUG_RADIO
+#define DEBUG_FLASH
+#define DEBUG_SENSORS
+#define DEBUG_SERIAL
+#define DEBUG_ENCODE
+*/

--- a/libraries/TerkinTelemetry/examples/http-cratedb/telemetry-cratedb.cpp
+++ b/libraries/TerkinTelemetry/examples/http-cratedb/telemetry-cratedb.cpp
@@ -1,0 +1,150 @@
+/*
+   
+   SQL over HTTP telemetry example.
+ 
+   Demonstrate submitting measurement data to CrateDB using SQL INSERT queries.
+
+   Note: You should not do that in a production system. Please use a message
+   bus like MQTT, with a corresponding broker like Mosquitto, and a data
+   historian like Kotori, in order to relay your telemetry messages properly.
+
+-------------------------------------------------------------------------
+
+   Copyright (C) 2015-2023  Andreas Motl <andreas.motl@panodata.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see: 
+   <http://www.gnu.org/licenses/gpl-3.0.txt>, 
+   or write to the Free Software Foundation,
+   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+-------------------------------------------------------------------------
+
+   Further information can be obtained at:
+
+   The Hiveeyes Project         https://hiveeyes.org/
+   Documentation                https://hiveeyes.org/docs/arduino/
+   Source code repository       https://github.com/hiveeyes/arduino
+   Community forum              https://community.hiveeyes.org/
+                                https://community.panodata.org/
+
+
+-------------------------------------------------------------------------   
+*/
+
+
+// ******************************************
+//                  Modules
+// ******************************************
+
+// Libraries
+// ---------
+#include <TerkinTelemetry.h>
+#include <Terrine.h>
+
+// Terrine: Application boilerplate
+Terrine terrine;
+
+
+// Imports
+// -------
+using namespace Terkin;
+
+
+// ******************************************
+//                Main program
+// ******************************************
+
+// Include configuration settings.
+#include "config.h"
+
+
+// Forward declarations.
+int main();
+void loop();
+void setup();
+void setup_telemetry();
+void setup_sensors();
+
+
+// Declare telemetry client.
+TelemetryClient* telemetry = NULL;
+
+
+// Program entrypoint for glibc.
+int main() {
+
+    terrine.log("===============================");
+    terrine.log("TerkinTelemetry CrateDB example");
+    terrine.log("===============================");
+    terrine.log();
+
+    setup();
+    loop();
+
+}
+
+// Program entrypoints for Arduino.
+
+// Arduino main setup function.
+void setup() {
+    setup_sensors();
+    setup_telemetry();
+}
+
+// Sensor setup.
+void setup_sensors() {
+    // Note: No sensors yet. This is just a telemetry demo program.
+}
+
+// TODO: Can this configuration style be improved?
+void TerkinData::DataManager::setup() {
+    this->field_names  = new DataHeader({"temperature", "humidity"});
+}
+
+// Telemetry setup with pluggable components.
+void setup_telemetry() {
+
+    // The address of the data acquisition channel.
+    ChannelAddress* address = new ChannelAddress(CHANNEL_REALM, CHANNEL_OWNER, CHANNEL_SITE, CHANNEL_DEVICE);
+
+    // The actual transmitter element.
+    CrateDBTransmitter* transmitter = new CrateDBTransmitter(CRATEDB_URL, CRATEDB_USERNAME, CRATEDB_PASSWORD);
+
+    // The telemetry client.
+    telemetry = new TelemetryClient(transmitter, address);
+}
+
+// Arduino main loop function.
+void loop() {
+
+    // 1. Read sensors
+
+    // Collect sensor data.
+    // Note: No sensors yet. This is just a telemetry demo program.
+    TerkinData::Measurement measurement;
+    measurement.data["temperature"] = 42.42;
+    measurement.data["humidity"] = 80;
+
+    // 2. Transmit data
+
+    // Transmit measurement to telemetry data collection server.
+    telemetry->transmit(measurement);
+
+    // Start sleeping cycle.
+#if defined(ARDUINO)
+    delay(2500);
+#else
+#endif
+
+}


### PR DESCRIPTION
## About

Building upon GH-79, this patch adds basic infrastructure for a transmitter component sending `SQL INSERT` statements to CrateDB over HTTP.
